### PR TITLE
do not xor bytes

### DIFF
--- a/uuid_test.go
+++ b/uuid_test.go
@@ -19,26 +19,44 @@ func TestUUID(t *testing.T) {
 		t.Fatalf("cannot make generator: %v", err)
 	}
 	uuid := g.Next()
-	buf[0] = 1 ^ 1
+	buf[0] = 1 + 1
 	if uuid != buf {
 		t.Fatalf("unexpected UUID; got %x; want %x", uuid, buf)
 	}
 	uuid = g.Next()
-	buf[0] = 1 ^ 2
+	buf[0] = 1 + 2
 	if uuid != buf {
 		t.Fatalf("unexpected next UUID; got %x; want %x", uuid, buf)
 	}
 }
 
+const step = 32768
+
 func TestUniqueness(t *testing.T) {
 	g := MustNewGenerator()
+	mc := make(chan map[[24]byte]int)
+	const nproc = 4
+	for i := 0; i < nproc; i++ {
+		go func() {
+			m := make(map[[24]byte]int)
+			for i := 0; i < step*10; i++ {
+				uuid := g.Next()
+				if old, ok := m[uuid]; ok {
+					t.Errorf("non-unique uuid seq at %d, other %d", i, old)
+				}
+				m[uuid] = i
+			}
+			mc <- m
+		}()
+	}
 	m := make(map[[24]byte]int)
-	for i := 0; i < 65537; i++ {
-		uuid := g.Next()
-		if old, ok := m[uuid]; ok {
-			t.Fatalf("non-unique uuid seq at %d, other %d", i, old)
+	for i := 0; i < nproc; i++ {
+		for uuid, iter := range <-mc {
+			if old, ok := m[uuid]; ok {
+				t.Errorf("non-unique uuid seq at %d, other %d", i, old)
+			}
+			m[uuid] = iter
 		}
-		m[uuid] = i
 	}
 }
 


### PR DESCRIPTION
do not xor bytes

The XOR is unnecessary - we can just start the counter in the right place
and avoid the need for it.

        name         old time/op  new time/op  delta
        Next         18.2ns ± 1%   8.9ns ± 0%  -50.93%  (p=0.016 n=5+4)
        Next-2       18.7ns ± 5%   9.2ns ± 6%  -50.79%  (p=0.008 n=5+5)
        Contended    18.9ns ± 3%   9.3ns ± 1%  -50.79%  (p=0.008 n=5+5)
        Contended-2  34.4ns ± 4%  33.3ns ± 2%   -3.20%  (p=0.032 n=5+5)
