### PR TITLE
require go 1.11 instead, 1.12 not released

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/rogpeppe/fastuuid
 
-go 1.12
+go 1.11

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/rogpeppe/fastuuid
+module github.com/spellgen/fastuuid
 
 go 1.11


### PR DESCRIPTION
Go modules supported in 1.11. Can't build unless you use a pre-release go version.