### PR TITLE
add parallel benchmark

### DIFF
--- a/uuid_test.go
+++ b/uuid_test.go
@@ -48,3 +48,12 @@ func BenchmarkNext(b *testing.B) {
 		g.Next()
 	}
 }
+
+func BenchmarkContended(b *testing.B) {
+	g := MustNewGenerator()
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			g.Next()
+		}
+	})
+}


### PR DESCRIPTION
When many UUIDs are being generated concurrently,
contention on the atomic counter can slow things down.

There might be ways to speed this up, but for now, just
add a parallel benchmark so we can measure the baseline.

Initial results with `go test -bench  . -cpu 1,2` on my machine (two physical cores):

	BenchmarkContended     	56413502	        18.3 ns/op
	BenchmarkContended-2   	82533951	        33.5 ns/op

Note that the 33.5ns/op measure is worse than it appears, because
that's wall ns/op, not cpu-ns/op (see https://github.com/golang/go/issues/31884), so the time is actually 67.0ns/op when contended.