### PR TITLE
set RFC4122 fields in Hex128

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,10 @@
 Package fastuuid provides fast UUID generation of 192 bit universally unique
 identifiers.
 
-It also provides simple support for 128-bit RFC-4122-like UUID strings.
+It also provides simple support for 128-bit RFC-4122 V4 UUID strings.
 
 Note that the generated UUIDs are not unguessable - each UUID generated from a
 Generator is adjacent to the previously generated UUID.
-
-It ignores RFC 4122.
 
 By way of comparison with two other popular UUID-generation packages,
 github.com/satori/go.uuid and github.com/google/uuid, here are some benchmarks:
@@ -32,13 +30,14 @@ github.com/satori/go.uuid and github.com/google/uuid, here are some benchmarks:
 ```go
 func Hex128(uuid [24]byte) string
 ```
-Hex128 returns an RFC4122-like representation of the first 128 bits of the given
+Hex128 returns an RFC4122 V4 representation of the first 128 bits of the given
 UUID. For example:
 
-    f81d4fae-7dec-11d0-a765-00a0c91e6bf6.
+    f81d4fae-7dec-41d0-8765-00a0c91e6bf6.
 
-It does not bother to set the version or variant bits of the UUID, as they only
-serve to reduce the randomness.
+Note: before encoding, it swaps bytes 6 and 9 so that all the varying bits of
+the UUID as returned from Generator.Next are reflected in the Hex128
+representation.
 
 If you want unpredictable UUIDs, you might want to consider hashing the uuid
 (using SHA256, for example) before passing it to Hex128.

--- a/uuid_test.go
+++ b/uuid_test.go
@@ -65,7 +65,8 @@ func TestHex128(t *testing.T) {
 	for i := range b {
 		b[i] = byte(i + 1)
 	}
-	got, want := Hex128(b), "01020304-0506-0708-090a-0b0c0d0e0f10"
+	// Note: byte 6 is swapped with byte 9.
+	got, want := Hex128(b), "01020304-0506-4a08-8907-0b0c0d0e0f10"
 	if got != want {
 		t.Fatalf("unexpected Hex128 result; got %q want %q", got, want)
 	}


### PR DESCRIPTION
It turns out that there is real life code that cares about the
RFC4122 variant and version bits, who knew?

So set those bits in the Hex128 result, swapping a couple
of bytes first to avoid duplicating UUIDs after 3.5e16 calls to Next.

The effect on performance turns out to be pretty small:

	name      old time/op  new time/op  delta
	Hex128-4  73.3ns ± 1%  75.2ns ± 1%  +2.48%  (p=0.008 n=5+5)